### PR TITLE
Add throws and doesNotThrow assertions

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,8 @@ The assertion api you can use within your test coroutines is pretty simple and h
 * notEqual
 * deepEqual
 * notDeepEqual
+* throws
+* doesNotThrow
 * fail
 
 You can use any other assertion library as well but a failing assertion will likely throw an exception which won't be properly tape reported

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -16,6 +16,12 @@ const assertions = {
     this.test.addAssertion(assertionResult);
     return assertionResult;
   },
+  throws(func, message = 'should throw'){
+    try { func(); } catch (e) { var thrown = true, error = e; }
+    const assertionResult = {pass: Boolean(thrown), expected: 'thrown error', actual: error, operator: 'throws', message};
+    this.test.addAssertion(assertionResult);
+    return assertionResult;
+  },
   notOk(val, message = 'should not be truthy'){
     const assertionResult = {pass: !Boolean(val), expected: 'falsy', actual: val, operator: 'notOk', message};
     this.test.addAssertion(assertionResult);
@@ -28,6 +34,12 @@ const assertions = {
   },
   notEqual(actual, expected, message = 'should not be equal'){
     const assertionResult = {pass: actual !== expected, actual, expected, message, operator: 'notEqual'};
+    this.test.addAssertion(assertionResult);
+    return assertionResult;
+  },
+  doesNotThrow(func, message = 'should not throw'){
+    try { func(); } catch (e) { var thrown = true, error = e; }
+    const assertionResult = {pass: !thrown, expected: 'no throws error', actual: error, operator: 'doesNotThrow', message};
     this.test.addAssertion(assertionResult);
     return assertionResult;
   },

--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -16,9 +16,16 @@ const assertions = {
     this.test.addAssertion(assertionResult);
     return assertionResult;
   },
-  throws(func, message = 'should throw'){
-    try { func(); } catch (e) { var thrown = true, error = e; }
-    const assertionResult = {pass: Boolean(thrown), expected: 'thrown error', actual: error, operator: 'throws', message};
+  doesNotThrow(func, expected, message){
+    if (typeof expected === 'string') {
+      [expected, message] = [message, expected];
+    }
+    try {
+      func();
+    } catch (error) {
+      var caught = { error };
+    }
+    const assertionResult = {pass: !caught, expected: 'no thrown error', actual: caught && caught.error, operator: 'doesNotThrow', message: message || 'should not throw'};
     this.test.addAssertion(assertionResult);
     return assertionResult;
   },
@@ -37,9 +44,26 @@ const assertions = {
     this.test.addAssertion(assertionResult);
     return assertionResult;
   },
-  doesNotThrow(func, message = 'should not throw'){
-    try { func(); } catch (e) { var thrown = true, error = e; }
-    const assertionResult = {pass: !thrown, expected: 'no throws error', actual: error, operator: 'doesNotThrow', message};
+  throws(func, expected, message){
+    if (typeof expected === 'string') {
+      [expected, message] = [message, expected];
+    }
+    try {
+      func();
+    } catch (error) {
+      var caught = { error };
+    }
+    let pass = Boolean(caught);
+    let actual = caught && caught.error;
+    if (expected instanceof RegExp) {
+      pass = expected.test(actual) || expected.test(actual && actual.message);
+      expected = String(expected);
+    }
+    else if (typeof expected === 'function' && caught) {
+      pass = actual instanceof expected;
+      actual = actual.constructor;
+    }
+    const assertionResult = {pass, expected, actual, operator: 'throws', message: message || 'should throw'};
     this.test.addAssertion(assertionResult);
     return assertionResult;
   },

--- a/test/assertions.js
+++ b/test/assertions.js
@@ -175,6 +175,72 @@ function testFunc () {
     t.end();
   });
 
+  plan('throws operator', t=> {
+    const tp = test({});
+    const a = assert(tp);
+    const {operator, message, pass} = a.throws(function () { throw new Error(); });
+    t.equal(operator, 'throws', 'should have the operator throws');
+    t.equal(message, 'should throw', 'should have the default message');
+    t.equal(pass, true, 'should have passed');
+    t.equal(tp.length, 1, 'should have added the assertion');
+    t.end();
+  });
+
+  plan('throws operator: change default message', t=> {
+    const tp = test({});
+    const a = assert(tp);
+    const {operator, message, pass} = a.throws(function () { throw new Error(); }, 'unexepected lack of error');
+    t.equal(operator, 'throws', 'should have the operator throws');
+    t.equal(message, 'unexepected lack of error', 'should have the custom message');
+    t.equal(pass, true, 'should have passed');
+    t.equal(tp.length, 1, 'should have added the assertion');
+    t.end();
+  });
+
+  plan('throws operator: failure', t=> {
+    const tp = test({});
+    const a = assert(tp);
+    const {operator, message, pass} = a.throws(function () {});
+    t.equal(operator, 'throws', 'should have the operator throws');
+    t.equal(message, 'should throw', 'should have the default message');
+    t.equal(pass, false, 'should not have passed');
+    t.equal(tp.length, 1, 'should have added the assertion');
+    t.end();
+  });
+
+  plan('doesNotThrow operator', t=> {
+    const tp = test({});
+    const a = assert(tp);
+    const {operator, message, pass} = a.doesNotThrow(function () {});
+    t.equal(operator, 'doesNotThrow', 'should have the operator doesNotThrow');
+    t.equal(message, 'should not throw', 'should have the default message');
+    t.equal(pass, true, 'should have passed');
+    t.equal(tp.length, 1, 'should have added the assertion');
+    t.end();
+  });
+
+  plan('doesNotThrow operator: change default message', t=> {
+    const tp = test({});
+    const a = assert(tp);
+    const {operator, message, pass} = a.doesNotThrow(function () {}, 'unexepected error');
+    t.equal(operator, 'doesNotThrow', 'should have the operator doesNotThrow');
+    t.equal(message, 'unexepected error', 'should have the custom message');
+    t.equal(pass, true, 'should have passed');
+    t.equal(tp.length, 1, 'should have added the assertion');
+    t.end();
+  });
+
+  plan('doesNotThrow operator: failure', t=> {
+    const tp = test({});
+    const a = assert(tp);
+    const {operator, message, pass} = a.doesNotThrow(function () { throw Error(); });
+    t.equal(operator, 'doesNotThrow', 'should have the operator doesNotThrow');
+    t.equal(message, 'should not throw', 'should have the default message');
+    t.equal(pass, false, 'should have passed');
+    t.equal(tp.length, 1, 'should have added the assertion');
+    t.end();
+  });
+
 }
 
 export default testFunc;

--- a/test/assertions.js
+++ b/test/assertions.js
@@ -178,7 +178,7 @@ function testFunc () {
   plan('throws operator', t=> {
     const tp = test({});
     const a = assert(tp);
-    const {operator, message, pass} = a.throws(function () { throw new Error(); });
+    const {operator, message, pass} = a.throws(()=> { throw new Error(); });
     t.equal(operator, 'throws', 'should have the operator throws');
     t.equal(message, 'should throw', 'should have the default message');
     t.equal(pass, true, 'should have passed');
@@ -189,7 +189,7 @@ function testFunc () {
   plan('throws operator: change default message', t=> {
     const tp = test({});
     const a = assert(tp);
-    const {operator, message, pass} = a.throws(function () { throw new Error(); }, 'unexepected lack of error');
+    const {operator, message, pass} = a.throws(()=> { throw new Error(); }, 'unexepected lack of error');
     t.equal(operator, 'throws', 'should have the operator throws');
     t.equal(message, 'unexepected lack of error', 'should have the custom message');
     t.equal(pass, true, 'should have passed');
@@ -200,7 +200,7 @@ function testFunc () {
   plan('throws operator: failure', t=> {
     const tp = test({});
     const a = assert(tp);
-    const {operator, message, pass} = a.throws(function () {});
+    const {operator, message, pass} = a.throws(()=> {});
     t.equal(operator, 'throws', 'should have the operator throws');
     t.equal(message, 'should throw', 'should have the default message');
     t.equal(pass, false, 'should not have passed');
@@ -208,13 +208,75 @@ function testFunc () {
     t.end();
   });
 
+  plan('throws operator: expected (RegExp)', t=> {
+    const tp = test({});
+    const a = assert(tp);
+    const error = new Error('Totally expected error');
+    const regexp = /^totally/i;
+    const {operator, message, pass, expected, actual} = a.throws(()=> { throw error; }, regexp);
+    t.equal(operator, 'throws', 'should have the operator throws');
+    t.equal(message, 'should throw', 'should have the default message');
+    t.equal(pass, true, 'should have passed');
+    t.equal(expected, '/^totally/i');
+    t.equal(actual, error);
+    t.equal(tp.length, 1, 'should have added the assertion');
+    t.end();
+  });
+
+  plan('throws operator: expected (RegExp, failed)', t=> {
+    const tp = test({});
+    const a = assert(tp);
+    const error = new Error('Not the expected error');
+    const regexp = /^totally/i;
+    const {operator, message, pass, expected, actual} = a.throws(()=> { throw error; }, regexp);
+    t.equal(operator, 'throws', 'should have the operator throws');
+    t.equal(message, 'should throw', 'should have the default message');
+    t.equal(pass, false, 'should have passed');
+    t.equal(expected, '/^totally/i');
+    t.equal(actual, error);
+    t.equal(tp.length, 1, 'should have added the assertion');
+    t.end();
+  });
+
+  plan('throws operator: expected (constructor)', t=> {
+    const tp = test({});
+    const a = assert(tp);
+    function CustomError() {}
+    const error = new CustomError();
+    const {operator, message, pass, expected, actual} = a.throws(()=> { throw error; }, CustomError);
+    t.equal(operator, 'throws', 'should have the operator throws');
+    t.equal(message, 'should throw', 'should have the default message');
+    t.equal(pass, true, 'should have passed');
+    t.equal(expected, CustomError);
+    t.equal(actual, CustomError);
+    t.equal(tp.length, 1, 'should have added the assertion');
+    t.end();
+  });
+
+  plan('throws operator: expected (constructor, failed)', t=> {
+    const tp = test({});
+    const a = assert(tp);
+    function CustomError() {}
+    const error = new Error('Plain error');
+    const {operator, message, pass, expected, actual} = a.throws(()=> { throw error; }, CustomError);
+    t.equal(operator, 'throws', 'should have the operator throws');
+    t.equal(message, 'should throw', 'should have the default message');
+    t.equal(pass, false, 'should have passed');
+    t.equal(expected, CustomError);
+    t.equal(actual, Error);
+    t.equal(tp.length, 1, 'should have added the assertion');
+    t.end();
+  });
+
   plan('doesNotThrow operator', t=> {
     const tp = test({});
     const a = assert(tp);
-    const {operator, message, pass} = a.doesNotThrow(function () {});
+    const {operator, message, pass, expected, actual} = a.doesNotThrow(()=> {});
     t.equal(operator, 'doesNotThrow', 'should have the operator doesNotThrow');
     t.equal(message, 'should not throw', 'should have the default message');
     t.equal(pass, true, 'should have passed');
+    t.equal(expected, 'no thrown error');
+    t.equal(actual, undefined);
     t.equal(tp.length, 1, 'should have added the assertion');
     t.end();
   });
@@ -233,10 +295,24 @@ function testFunc () {
   plan('doesNotThrow operator: failure', t=> {
     const tp = test({});
     const a = assert(tp);
-    const {operator, message, pass} = a.doesNotThrow(function () { throw Error(); });
+    const {operator, message, pass} = a.doesNotThrow(()=> { throw Error(); });
     t.equal(operator, 'doesNotThrow', 'should have the operator doesNotThrow');
     t.equal(message, 'should not throw', 'should have the default message');
     t.equal(pass, false, 'should have passed');
+    t.equal(tp.length, 1, 'should have added the assertion');
+    t.end();
+  });
+
+  plan('doesNotThrow operator: expected (ignored)', t=> {
+    const tp = test({});
+    const a = assert(tp);
+    function CustomError() {}
+    const {operator, message, pass, expected, actual} = a.doesNotThrow(()=> {}, CustomError);
+    t.equal(operator, 'doesNotThrow', 'should have the operator doesNotThrow');
+    t.equal(message, 'should not throw', 'should have the default message');
+    t.equal(pass, true, 'should have passed');
+    t.equal(expected, 'no thrown error');
+    t.equal(actual, undefined);
     t.equal(tp.length, 1, 'should have added the assertion');
     t.end();
   });


### PR DESCRIPTION
This PR adds simplified versions of tape's `throws` and `doesNotThrow` assertions.


To keep in the spirit of zora I kept the implementation simple and short. It only checks for a `thrown` error and doesn't compare it against an `expected` error message, though I'd be more than happy to add that if you want.