### PR TITLE
Fix: throws actual value use message

### DIFF
--- a/lib/assertions.js
+++ b/lib/assertions.js
@@ -76,6 +76,7 @@ const Assertion = {
 		actual = caught && caught.error;
 		if (expected instanceof RegExp) {
 			pass = expected.test(actual) || expected.test(actual && actual.message);
+			actual = actual && actual.message || actual;
 			expected = String(expected);
 		} else if (typeof expected === 'function' && caught) {
 			pass = actual instanceof expected;

--- a/test/assertions.js
+++ b/test/assertions.js
@@ -213,7 +213,7 @@ test('throws operator: expected (RegExp)', t => {
 	t.equal(description, 'should throw', 'should have the default description');
 	t.equal(pass, true, 'should have passed');
 	t.equal(expected, '/^totally/i');
-	t.equal(actual, error);
+	t.equal(actual, error.message);
 	t.equal(items.length, 1, 'should have added the assertion');
 	t.end();
 });
@@ -230,7 +230,7 @@ test('throws operator: expected (RegExp, failed)', t => {
 	t.equal(description, 'should throw', 'should have the default description');
 	t.equal(pass, false, 'should have passed');
 	t.equal(expected, '/^totally/i');
-	t.equal(actual, error);
+	t.equal(actual, error.message);
 	t.equal(items.length, 1, 'should have added the assertion');
 	t.end();
 });


### PR DESCRIPTION
Closes #14

This updates the `throws` assertion to set the value of `actual` to `error.message`, if the property exists. 

- `actual` uses `.message`, if it exists
- update the tests

```js
test('throws', t => {
  t.throws(
      () => { JSON.parse('hello') },
      new RegExp('welp...')
    );
})
```

```
not ok 1 - should throw
  ---
  expected: "/welp.../"
  actual: "Unexpected token h in JSON at position 0"
  at: " group.test.t (/Users/d33t/repos/horsey-sauce/test/run.mjs:55:7)"
  operator: "throws"
  ...
```

I tried to run the tests locally, but I get an unresolved dependencies error from rollup. Seems it can't resolve `./combinators` in the `tests/index.js` file. Circle should tell me if I got the tests right at least...