### PR TITLE
Add badges to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 Fast javascript test runner for **nodejs** and **browsers**
 
-[![CircleCI](https://circleci.com/gh/lorenzofox3/zora.svg?style=svg)](https://circleci.com/gh/lorenzofox3/zora)
+[![CircleCI](https://badgen.net/circleci/github/lorenzofox3/zora)](https://circleci.com/gh/lorenzofox3/zora)
+[![npm](https://badgen.net/npm/v/zora)](https://www.npmjs.com/package/zora)
+[![Install Size](https://badgen.net/packagephobia/install/zora)](https://packagephobia.now.sh/result?p=zora)
 
 ## installation
 ``npm install --save-dev zora``


### PR DESCRIPTION
These badges should load super fast and give some details about npm version and install size. Also clicking each badge will link to appropriate place.