### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,6 @@ However, you'll be able to group your tests if you wish to conserve some state b
 The sequence is simply controlled by AsyncFunction (and await keyboard)
 
 ```Javascript
-
 let state = 0;
 
 test('test 1', t => {
@@ -197,6 +196,8 @@ test('grouped', async t => {
     });
 });
 ```
+
+> NOTE: the wait() function can be handy to wait for dom-updates e.g. : `const wait = (time = 200) => new Promise(resolve =>setTimeout(resolve, time))`
 
 ### BDD style
 


### PR DESCRIPTION
I was fiddling with `setTimeout( () => t.ok(true)` to get async tests to work on a jquery app.
This (obviously) did not work, so i went back to README.md.

> I tried using the wait() function, but it turned out it wasn't declared. 

I finally found the wait() function in the issuetracker (quite essential for waiting for dom-rerenders), so I   
provided the wait() function as a sidenote in the README.md (instead of including it in the codesnippet, which would kindof increase the complexity)