### PR TITLE
Make sure Symbols are displayed in test output

### DIFF
--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -14,11 +14,19 @@ const print = (message: string, offset = 0): void => {
     console.log(message.padStart(message.length + (offset * 4))); // 4 white space used as indent (see tap-parser)
 };
 
+const stringifySymbol = (key, value) => {
+    if (typeof value === 'symbol') {
+        return value.toString()
+    }
+
+    return value
+}
+
 const printYAML = (obj: object, offset = 0): void => {
     const YAMLOffset = offset + 0.5;
     print('---', YAMLOffset);
     for (const [prop, value] of Object.entries(obj)) {
-        print(`${prop}: ${JSON.stringify(value)}`, YAMLOffset + 0.5);
+        print(`${prop}: ${JSON.stringify(stringifySymbol(null, value), stringifySymbol)}`, YAMLOffset + 0.5);
     }
     print('...', YAMLOffset);
 };

--- a/test/samples/cases/symbol.js
+++ b/test/samples/cases/symbol.js
@@ -1,0 +1,6 @@
+const {test} = require('../../../dist/bundle/index.js');
+
+test('symbol tester 1', t => {
+    t.equal(Symbol('foo'),Symbol('bar'),'Symbol foo should equal Symbol bar');
+    t.equal({symbol: Symbol('foo')},{symbol:Symbol('bar')}, 'Property Symbol foo should equal Symbol bar')
+});

--- a/test/samples/output/symbol.indent.txt
+++ b/test/samples/output/symbol.indent.txt
@@ -1,0 +1,24 @@
+TAP version 13
+# Subtest: symbol tester 1
+    not ok 1 - Symbol foo should equal Symbol bar
+      ---
+        wanted: "Symbol(bar)"
+        found: "Symbol(foo)"
+        at:{STACK}
+        operator: "equal"
+      ...
+    not ok 2 - Property Symbol foo should equal Symbol bar
+      ---
+        wanted: {"symbol":"Symbol(bar)"}
+        found: {"symbol":"Symbol(foo)"}
+        at:{STACK}
+        operator: "equal"
+      ...
+    1..2
+not ok 1 - symbol tester 1 # {TIME}
+1..1
+
+# not ok
+# success: 0
+# skipped: 0
+# failure: 2

--- a/test/samples/output/symbol.txt
+++ b/test/samples/output/symbol.txt
@@ -1,0 +1,22 @@
+TAP version 13
+# symbol tester 1
+not ok 1 - Symbol foo should equal Symbol bar
+  ---
+    actual: "Symbol(foo)"
+    expected: "Symbol(bar)"
+    operator: "equal"
+    at:{STACK}
+  ...
+not ok 2 - Property Symbol foo should equal Symbol bar
+  ---
+    actual: {"symbol":"Symbol(foo)"}
+    expected: {"symbol":"Symbol(bar)"}
+    operator: "equal"
+    at:{STACK}
+  ...
+1..2
+
+# not ok
+# success: 0
+# skipped: 0
+# failure: 2


### PR DESCRIPTION
I was writing some tests involving [Symbol](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol)s and it was really annoying to see

```
    actual: undefined
    expected: undefined
```

in the output of the failing tests.