### PR TITLE
Add exports property to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,10 @@
   "main": "./dist/bundle/index",
   "module": "./dist/bundle/module.js",
   "types": "./dist/declarations/index.d.ts",
+  "exports": {
+    "import": "./dist/bundle/index.mjs",
+    "require": "./dist/bundle/index.js"
+  },
   "files": [
     "dist/bundle",
     "dist/declarations"


### PR DESCRIPTION
This resolves #62, allowing Node 13 and 14 to use native ES modules to import the correct build.