### PR TITLE
benchmark: use jest --env=node for a more accurate comparison

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "bench:mocha": "time mocha ./benchmarks/mocha/test/",
     "bench:mocha:parallel": "time mocha --parallel ./benchmarks/mocha/test/",
     "bench:tape": "time node ./benchmarks/tape/index",
-    "bench:jest": "time jest",
+    "bench:jest": "time jest --env=node",
     "bench:uvu": "time uvu -r esm ./benchmarks/uvu test",
     "bench:pta": "time pta benchmarks/zora/test/*.js",
     "test:unit": "rollup -c ./rollup/test.js | node",


### PR DESCRIPTION
## Description

- Jest uses JSDOM by default whereas the others don't

- There's probably other optimizations to be made here as Jest is
  focused on usability out-of-the-box as opposed to being the most
  performant out-of-the-box
  - e.g. both AVA and Jest transpile code by default
  - using the [Jest Circus Runner](https://jestjs.io/blog/2020/05/05/jest-26)
    could also make it faster
  - this is just me making it a little bit closer with an optimization
    I'm quite familiar with and instantly recognized was missing

- benchmark for Jest will have to be updated to account for this,
  didn't run on my computer as all the numbers will be different
  - benchmark also [currently says Jest 25](https://github.com/lorenzofox3/zora/blame/01e8e1a0c001af33bf45608aee0525e12b7af365/README.md#L67), but Jest 26 is listed in
    [the package.json#devDependencies](https://github.com/lorenzofox3/zora/blob/01e8e1a0c001af33bf45608aee0525e12b7af365/package.json#L57), not sure if the benchmark is
    out-of-date or just the version

- this commit is effectively the same as the one I made to uvu:
  https://github.com/lukeed/uvu/commit/f9f268c9d59930cac3d3673a6dc3e0375be85968

## Tags

Effectively the same PR that I made in `uvu`: https://github.com/lukeed/uvu/pull/28

I found `zora` from your https://github.com/lukeed/uvu/pull/31, which also talks about better benchmarks 😅 
