### PR TITLE
Add deno support to findConfigurationFlag

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,10 @@ const findConfigurationFlag = (name) => {
     if (typeof process !== 'undefined') {
         return process.env[name] === 'true';
         // @ts-ignore
+    } else if (typeof Deno !== 'undefined') {
+        // @ts-ignore
+        return Deno.env.get(name) === 'true';
+        // @ts-ignore
     } else if (typeof window !== 'undefined') {
         // @ts-ignore
         return Boolean(window[name]);


### PR DESCRIPTION
Hi @lorenzofox3!

Thanks for such a great project. I've been using `zora` with [ESBuild](https://github.com/evanw/esbuild) and it's such a breath of fresh air using tools that are so clean and so _fast_!

### What this PR does

Adds support for loading configuration flags from environment variables when running `zora` in Deno.

### Why

I've been using `zora` on a few projects and I really love it as a way to run tests that work in any JS environment.

For one of my projects (still private, unfortunately), I'm supporting Deno. `zora` itself has been working great with Deno -- at least when using a bundler; I haven't tried running it from e.g. unpkg -- but I'd like to be able to set configuration flags using environment variables.

Note that the change in this PR is just a minor DX improvement for packages that only target Node and Deno. It's not strictly necessary because Deno's supports using `window` as a global object, so doing something like this does work:

```js
if (typeof window !== "undefined") {
  // @ts-expect-error
  window.INDENT = true;
}
```

It's relatively minor bit of boilerplate, and it's required when targeting browsers anyway, but I still wish I didn't need it for packages that don't intend to be run in browsers.

AFAIK, outside `findConfigurationFlags`, the rest of `zora` is Just JavaScript (:sparkles:), so I don't think Deno requires any additional changes to work with `zora`. However, I totally understand that you might not want to add the burden of having to support an additional runtime. Maybe this this could be a first step towards something like "experimental support for Deno"? :shrug:

Anyway, thanks again for such a great project! Let me know if you have any questions.

### Related

- [`Deno.env` API](https://doc.deno.land/https/raw.githubusercontent.com/denoland/deno/master/cli/dts/lib.deno.ns.d.ts#Deno.env)