### PR TITLE
Add package.json to exports for React Native

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,11 @@
   "module": "./dist/bundle/module.js",
   "types": "./dist/declarations/index.d.ts",
   "exports": {
-    "import": "./dist/bundle/index.mjs",
-    "require": "./dist/bundle/index.js"
+    "./package.json": "./package.json",
+    ".": {
+      "import": "./dist/bundle/index.mjs",
+      "require": "./dist/bundle/index.js"
+    }
   },
   "files": [
     "dist/bundle",


### PR DESCRIPTION
This is required or Metro, React Native's bundler, complains and the build breaks.