### PR TITLE
Update Diff reporter theme

### DIFF
--- a/reporters/src/diff/theme.js
+++ b/reporters/src/diff/theme.js
@@ -3,7 +3,7 @@ import { compose } from '../utils.js';
 import { bold, underline } from 'colorette';
 import { withMargin } from './utils.js';
 
-const badge = (fn) => compose([bold, fn, withMargin, String]);
+const badge = (fn) => compose([fn, bold, withMargin, String]);
 
 export const createTheme = ({
   bgError = colors.bgRed,

--- a/reporters/src/diff/theme.js
+++ b/reporters/src/diff/theme.js
@@ -3,14 +3,14 @@ import { compose } from '../utils.js';
 import { bold, underline } from 'colorette';
 import { withMargin } from './utils.js';
 
-const badge = (fn) => compose([fn, withMargin, String]);
+const badge = (fn) => compose([bold, fn, withMargin, String]);
 
 export const createTheme = ({
-  bgError = colors.bgRedBright,
-  bgSuccess = colors.bgGreenBright,
-  bgSkip = colors.bgYellowBright,
+  bgError = colors.bgRed,
+  bgSuccess = colors.bgGreen,
+  bgSkip = colors.bgYellow,
   disableFont = colors.gray,
-  badgeFont = colors.whiteBright,
+  badgeFont = colors.whiteBright, // might be more readable as colors.black
   adornerFont = colors.cyan,
 } = {}) => {
   const success = compose([bgSuccess, badgeFont]);

--- a/reporters/src/diff/theme.js
+++ b/reporters/src/diff/theme.js
@@ -10,7 +10,7 @@ export const createTheme = ({
   bgSuccess = colors.bgGreen,
   bgSkip = colors.bgYellow,
   disableFont = colors.gray,
-  badgeFont = colors.whiteBright, // might be more readable as colors.black
+  badgeFont = colors.whiteBright,
   adornerFont = colors.cyan,
 } = {}) => {
   const success = compose([bgSuccess, badgeFont]);


### PR DESCRIPTION
Compared to the screenshot for Diff reporter at https://github.com/lorenzofox3/zora/tree/master/reporters , I am seeing pink and very light green badge backgrounds with very light white text inside, instead of red and dark green badge backgrounds with bold white text inside.

I'm not sure if something changed since that screenshot was made, but it's unreadable for me.