### PR TITLE
Esm wrap

### DIFF
--- a/pta/readme.md
+++ b/pta/readme.md
@@ -1,6 +1,6 @@
 # PTA
 
-Test runner for any zora testing program, using node (version >= 16). 
+Test runner for any zora testing program, using node (version >= 16).
 
 ## Installation
 
@@ -8,11 +8,11 @@ Test runner for any zora testing program, using node (version >= 16).
 
 ## Usage
 
-example: 
+example:
 
 ``pta test/**/*.js``
 
-Note: it should work with both module format commonjs and ES 
+Note: it should work with both module format commonjs and ES
 
 ## Options
 
@@ -24,9 +24,6 @@ Usage
     --only             Runs zora in "only mode"
 
     --reporter, -R          One of tap, log. Otherwise it will use the default reporter
-
-    --module-loader         "es" or "cjs". Force the way files are loaded: "cjs" will use "require",
-                            "es" will use "import". If not specified it is inferred from the package.json
 
 
   Examples

--- a/pta/src/usage.txt
+++ b/pta/src/usage.txt
@@ -10,9 +10,6 @@ Usage
 
     --reporter, -R          One of tap, log. Otherwise it will use the default reporter
 
-    --module-loader         "es" or "cjs". Force the way files are loaded: "cjs" will use "require",
-                            "es" will use "import". If not specified it is inferred from the package.json
-
 
   Examples
     pta

--- a/zora/es.js
+++ b/zora/es.js
@@ -1,0 +1,1 @@
+export * from './dist/index.cjs';

--- a/zora/package.json
+++ b/zora/package.json
@@ -23,7 +23,7 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
-      "import": "./dist/index.js",
+      "import": "./es.js",
       "require": "./dist/index.cjs"
     },
     "./cjs": "./dist/index.cjs",
@@ -43,7 +43,8 @@
     "zora-assert": "*"
   },
   "files": [
-    "dist"
+    "dist",
+    "es.js"
   ],
   "author": "@lorenzofox3 <Laurent RENARD>",
   "license": "MIT",


### PR DESCRIPTION
* ~~zora now only ships cjs dist~~. Use esm wrapper to reuse cjs instance in Nodejs environment.
* esm build file is accessible in native web consumption.
* removed `--module-loader` from pta, but kept it in the arg schema to avoid breaking user's existing command line.

As a result, cjs and es test code can now be reported together by zora.

closes #155, #118