### PR TITLE
chore: add cjs and mjs to default file patterns

### DIFF
--- a/pta/src/bin.js
+++ b/pta/src/bin.js
@@ -26,12 +26,12 @@ const reporterMap = {
 };
 
 const DEFAULT_FILE_PATTERNS = [
-  '**/test.js',
-  '**/*.spec.js',
-  '**/*.test.js',
-  '**/test/**/*.js',
-  '**/tests/**/*.js',
-  '**/__tests__/**/*.js',
+  '**/test.{js,cjs,mjs}',
+  '**/*.spec.{js,cjs,mjs}',
+  '**/*.test.{js,cjs,mjs}',
+  '**/test/**/*.{js,cjs,mjs}',
+  '**/tests/**/*.{js,cjs,mjs}',
+  '**/__tests__/**/*.{js,cjs,mjs}',
   '!**/node_modules',
   '!node_modules',
 ];


### PR DESCRIPTION
Since now pta supports mix of cjs and esm test files, cjs and mjs can to add to the default patterns together.