### PR TITLE
feat: add rejects assertion

### DIFF
--- a/assert/readme.md
+++ b/assert/readme.md
@@ -26,6 +26,15 @@ export interface ErrorAssertionFunction {
     (fn: Function, description?: string): IAssertionResult<string>;
 }
 
+export type RejectsErrorAssertionFunction = {
+  (
+    fn: Promise<any> | (() => Promise<any>),
+    expected: RegExp | Function,
+    description?: string
+  ): Promise<IAssertionResult<string | Function>>;
+  (fn: Promise<any> | (() => Promise<any>), description?: string): Promise<IAssertionResult<string>>;
+};
+
 export interface MessageAssertionFunction {
     (message?: string): AssertionResult<string>;
 }
@@ -76,6 +85,8 @@ interface Assert {
     fail: MessageAssertionFunction;
 
     throws: ErrorAssertionFunction;
+    
+    rejects: RejectsErrorAssertionFunction;
 }
 ```
 

--- a/assert/src/assert.js
+++ b/assert/src/assert.js
@@ -104,6 +104,45 @@ export const throws = (func, expected, description = 'should throw') => {
   };
 };
 
+export const rejects = async (func, expected, description = 'should reject') => {
+  let caught;
+  let pass;
+  let actual;
+  if (typeof expected === 'string') {
+    [expected, description] = [void 0, expected];
+  }
+  try {
+    if (func instanceof Promise) {
+      await func
+    } else {
+      await func();
+    }
+  } catch (err) {
+    caught = { error: err };
+  }
+  pass = caught !== undefined;
+  actual = caught?.error;
+
+  if (expected instanceof RegExp) {
+    pass = expected.test(actual) || expected.test(actual && actual.message);
+    actual = actual?.message ?? actual;
+    expected = String(expected);
+  } else if (typeof expected === 'function' && caught) {
+    pass = actual instanceof expected;
+    actual = actual.constructor;
+  } else {
+    actual = pass ? 'error rejected' : 'no error rejected';
+  }
+
+  return {
+    pass,
+    actual,
+    expected: expected ?? 'any error rejected',
+    description: description,
+    operator: Operator.REJECTS,
+  };
+};
+
 export const Assert = {
   equal,
   equals: equal,
@@ -123,4 +162,5 @@ export const Assert = {
   falsy: notOk,
   fail,
   throws,
+  rejects,
 };

--- a/assert/src/index.d.ts
+++ b/assert/src/index.d.ts
@@ -24,6 +24,15 @@ export type ErrorAssertionFunction = {
   (fn: Function, description?: string): IAssertionResult<string>;
 };
 
+export type RejectsErrorAssertionFunction = {
+  (
+    fn: Promise<any> | (() => Promise<any>),
+    expected: RegExp | Function,
+    description?: string
+  ): Promise<IAssertionResult<string | Function>>;
+  (fn: Promise<any> | (() => Promise<any>), description?: string): Promise<IAssertionResult<string>>;
+};
+
 export interface MessageAssertionFunction {
   (message?: string): IAssertionResult<string>;
 }
@@ -64,6 +73,8 @@ export interface IAssert {
   fail: MessageAssertionFunction;
 
   throws: ErrorAssertionFunction;
+
+  rejects: RejectsErrorAssertionFunction;
 }
 
 declare function factory(options?: IAssertOptions): IAssert;

--- a/assert/src/utils.js
+++ b/assert/src/utils.js
@@ -7,6 +7,7 @@ export const Operator = {
   IS_NOT: 'isNot',
   FAIL: 'fail',
   THROWS: 'throws',
+  REJECTS: 'rejects',
 };
 
 const specFnRegexp = /zora_spec_fn/;

--- a/assert/test/assert.js
+++ b/assert/test/assert.js
@@ -8,6 +8,7 @@ import {
   notOk,
   ok,
   throws,
+  rejects,
 } from '../src/assert.js';
 
 test('"equal" operator', ({ eq }) => {
@@ -363,6 +364,186 @@ test('throws', ({ eq }) => {
       expected: 'any error thrown',
       actual: 'no error thrown',
       operator: 'throws',
+    }
+  );
+});
+
+test('rejects (promise fn return)', async ({ eq }) => {
+  const regexp = /^totally/i;
+
+  class CustomError extends Error {
+    constructor() {
+      super('custom error');
+    }
+  }
+
+  eq(
+    await rejects(async () => {
+      throw new Error('Totally expected error');
+    }, regexp),
+    {
+      pass: true,
+      actual: 'Totally expected error',
+      expected: '/^totally/i',
+      description: 'should reject',
+      operator: 'rejects',
+    },
+    'expected is a regexp, passing'
+  );
+
+  eq(
+    await rejects(async () => {
+      throw new Error('not the expected error');
+    }, regexp),
+    {
+      pass: false,
+      actual: 'not the expected error',
+      expected: '/^totally/i',
+      description: 'should reject',
+      operator: 'rejects',
+    },
+    'expected is a regexp, failing'
+  );
+
+  eq(
+    await rejects(async () => {
+      throw new CustomError();
+    }, CustomError),
+    {
+      pass: true,
+      actual: CustomError,
+      expected: CustomError,
+      description: 'should reject',
+      operator: 'rejects',
+    },
+    'expected is a constructor, passing'
+  );
+
+  eq(
+    await rejects(async () => {
+      throw new Error();
+    }, CustomError),
+    {
+      pass: false,
+      actual: Error,
+      expected: CustomError,
+      description: 'should reject',
+      operator: 'rejects',
+    },
+    'expected is a constructor, failing'
+  );
+
+  eq(
+    await rejects(async () => {
+      throw new Error('whatever');
+    }, 'custom description'),
+    {
+      pass: true,
+      description: 'custom description',
+      expected: 'any error rejected',
+      actual: 'error rejected',
+      operator: 'rejects',
+    }
+  );
+
+  eq(
+    await rejects(async () => {}),
+    {
+      pass: false,
+      description: 'should reject',
+      expected: 'any error rejected',
+      actual: 'no error rejected',
+      operator: 'rejects',
+    }
+  );
+});
+
+test('rejects (promise)', async ({ eq }) => {
+  const regexp = /^totally/i;
+
+  class CustomError extends Error {
+    constructor() {
+      super('custom error');
+    }
+  }
+
+  eq(
+    await rejects(Promise.reject(
+      new Error('Totally expected error'),
+    ), regexp),
+    {
+      pass: true,
+      actual: 'Totally expected error',
+      expected: '/^totally/i',
+      description: 'should reject',
+      operator: 'rejects',
+    },
+    'expected is a regexp, passing'
+  );
+
+  eq(
+    await rejects(Promise.reject(
+      new Error('not the expected error'),
+    ), regexp),
+    {
+      pass: false,
+      actual: 'not the expected error',
+      expected: '/^totally/i',
+      description: 'should reject',
+      operator: 'rejects',
+    },
+    'expected is a regexp, failing'
+  );
+
+  eq(
+    await rejects(Promise.reject(
+      new CustomError(),
+    ), CustomError),
+    {
+      pass: true,
+      actual: CustomError,
+      expected: CustomError,
+      description: 'should reject',
+      operator: 'rejects',
+    },
+    'expected is a constructor, passing'
+  );
+
+  eq(
+    await rejects(Promise.reject(
+      new Error(),
+    ), CustomError),
+    {
+      pass: false,
+      actual: Error,
+      expected: CustomError,
+      description: 'should reject',
+      operator: 'rejects',
+    },
+    'expected is a constructor, failing'
+  );
+
+  eq(
+    await rejects(Promise.reject(
+      new Error('whatever'),
+    ), 'custom description'),
+    {
+      pass: true,
+      description: 'custom description',
+      expected: 'any error rejected',
+      actual: 'error rejected',
+      operator: 'rejects',
+    }
+  );
+
+  eq(
+    await rejects(Promise.resolve()),
+    {
+      pass: false,
+      description: 'should reject',
+      expected: 'any error rejected',
+      actual: 'no error rejected',
+      operator: 'rejects',
     }
   );
 });


### PR DESCRIPTION
I found this [useful assertion](https://github.com/avajs/ava/blob/v4.3.0/docs/03-assertions.md#throwsasyncthrower-expectation-message) missing. Its implementation is inspired by `throws` from zora.