### PR TITLE
fix: use correct default ESM entry

### DIFF
--- a/zora/es.js
+++ b/zora/es.js
@@ -1,1 +1,1 @@
-export * from './dist/index.cjs';
+export * from './dist/index.js';


### PR DESCRIPTION
The current default ESM entry in zora is `./es.js`, which resolves to the `dist/index.cjs` bundle. But that is a CommonJS bundle, which doesn't work with Vite. Yet I found another correct setup is also defined in current `package.json`, which resolves `import 'zora/es'` statement to `dist/index.js`, this works well.

So currently for importing zora in Vite, user needs to alias `"zora"` to "zora/es". This PR is a simple fix.

Current config pasted here:

``` js
  "exports": {
    "./package.json": "./package.json",
    ".": {
      // this entry should also import ESM bundle
      "import": "./es.js",
      "require": "./dist/index.cjs"
    },
    "./cjs": "./dist/index.cjs",
    // this works
    "./es": "./dist/index.js"
  },
```
