### PR TITLE
Fix Maps/Sets/TypedArrays reporting

### DIFF
--- a/reporters/src/diff/diagnostic/equal.js
+++ b/reporters/src/diff/diagnostic/equal.js
@@ -1,7 +1,7 @@
 import { diffChars, diffJson } from 'diff';
 import { leftPad, typeAsString } from '../utils.js';
 import { EOL } from 'os';
-import { compose } from '../../utils.js';
+import { compose, createReplacer } from '../../utils.js';
 
 const actualParts = ({ added }) => added !== true;
 const expectedParts = ({ removed }) => removed !== true;
@@ -141,6 +141,9 @@ export default (theme) => {
       if (expected.constructor === Date) {
         return diffDates(theme)({ expected, actual });
       }
+
+      expected = JSON.parse(JSON.stringify(expected, createReplacer()));
+      actual = JSON.parse(JSON.stringify(actual, createReplacer()));
       return diffObjects(theme)({ actual, expected });
     },
   };

--- a/reporters/src/diff/writer/diagnostic.test.js
+++ b/reporters/src/diff/writer/diagnostic.test.js
@@ -94,6 +94,34 @@ test(`diagnostic messages`, (t) => {
       );
     });
 
+    t.test(`expected an actual are Maps`, (t) => {
+      const expected = new Map([
+        ['a', 123],
+        ['nested', { answer: 42 }],
+      ]);
+      const actual = new Map([
+        ['a', 124],
+        ['nested', { answer: 42 }],
+      ]);
+
+      t.eq(
+        getMessage({ expected, actual }),
+        `\
+diff in objects:
+  <errorBadge>- actual</errorBadge> <successBadge>+ expected</successBadge>
+
+     <disable>{</disable>
+     <disable>  "Map": {</disable>
+  <errorBadge>-</errorBadge>     "a": 124,
+  <successBadge>+</successBadge>     "a": 123,
+     <disable>    "nested": {</disable>
+     <disable>      "answer": 42</disable>
+     <disable>    }</disable>
+     <disable>  }</disable>
+     <disable>}</disable>`
+      );
+    });
+
     t.test(`expected and actual are numbers`, (t) => {
       const expected = 5;
       const actual = 3;

--- a/reporters/src/tap/writer.test.js
+++ b/reporters/src/tap/writer.test.js
@@ -68,6 +68,27 @@ test(`tap writer`, ({ test }) => {
       );
       check(['ok 66 - some test']);
     });
+    test('simple failing assertion', ({ eq }) => {
+      const { writer, check } = createTestWriter({ eq });
+      writer.printAssertion(
+        {
+          data: {
+            pass: false,
+            actual: { a: 123 },
+            expected: { b: 456 },
+            description: 'some failing test',
+          },
+        },
+        { id: 666 }
+      );
+      check([
+        'not ok 666 - some failing test',
+        `  ---`,
+        `    actual: {"a":123}`,
+        `    expected: {"b":456}`,
+        `  ...`,
+      ]);
+    });
   });
 
   test('print summary', ({ eq }) => {

--- a/reporters/src/tap/writer.test.js
+++ b/reporters/src/tap/writer.test.js
@@ -89,6 +89,27 @@ test(`tap writer`, ({ test }) => {
         `  ...`,
       ]);
     });
+    test('es6 Map failing assertion', ({ eq }) => {
+      const { writer, check } = createTestWriter({ eq });
+      writer.printAssertion(
+        {
+          data: {
+            pass: false,
+            actual: new Map([['a', 123]]),
+            expected: new Map([['b', 456]]),
+            description: 'some failing test',
+          },
+        },
+        { id: 666 }
+      );
+      check([
+        'not ok 666 - some failing test',
+        `  ---`,
+        `    actual: {"Map":{"a":123}}`,
+        `    expected: {"Map":{"b":456}}`,
+        `  ...`,
+      ]);
+    });
   });
 
   test('print summary', ({ eq }) => {

--- a/reporters/src/utils.js
+++ b/reporters/src/utils.js
@@ -4,7 +4,8 @@ const isNode = typeof process !== 'undefined';
 
 export const flatDiagnostic = ({ pass, description, ...rest }) => rest;
 
-const createReplacer = () => {
+export const createReplacer = () => {
+  const TypedArray = Object.getPrototypeOf(Uint8Array);
   const visited = new Set();
   return (key, value) => {
     if (isObject(value)) {
@@ -17,6 +18,16 @@ const createReplacer = () => {
 
     if (typeof value === 'symbol') {
       return value.toString();
+    }
+
+    if (value instanceof Map) {
+      return { Map: Object.fromEntries(value) };
+    }
+    if (value instanceof Set) {
+      return { Set: Array.from(value) };
+    }
+    if (value instanceof TypedArray) {
+      return { [value.constructor?.name || 'TypedArray']: Array.from(value) };
     }
 
     return value;

--- a/reporters/src/utils.test.js
+++ b/reporters/src/utils.test.js
@@ -26,6 +26,18 @@ test(`serialize`, ({ test }) => {
     );
   });
 
+  test(`ES6 structures`, ({ test }) => {
+    test(`Map`, ({ eq }) => {
+      eq(stringify(new Map([['a', 123]])), `{"Map":{"a":123}}`);
+    });
+    test(`Set`, ({ eq }) => {
+      eq(stringify(new Set(['a', 'b'])), `{"Set":["a","b"]}`);
+    });
+    test(`TypedArray`, ({ eq }) => {
+      eq(stringify(Uint8Array.from([1, 2, 3])), `{"Uint8Array":[1,2,3]}`);
+    });
+  });
+
   test(`circular dependencies`, ({ eq }) => {
     const a = {
       foo: 'bar',


### PR DESCRIPTION
These will likely fail until #176  is merged, however after that this should fix reporting of Maps/Sets/TypedArrays.
I have made them report as `{"Map": {"k":"v",...}}` which is maybe not ideal. Additionally there's now a JSON encode/decode roundtrip in the diff report in order to be able to reuse the code in `createReplacer` without writing/pulling in a recursive object visitor algo, again this is maybe not ideal.

The only other low-effort way I could think of for this though would be to serialize directly as e.g. `{"k":"v"}`, and sets/arrays as `["a","b",...]`, i.e. make them indistinguishable from plain objects and arrays. That would likely still have the JSON round tripping in it as well.

