### PR TITLE
change disableFont to colors.dim

### DIFF
--- a/reporters/src/diff/theme.js
+++ b/reporters/src/diff/theme.js
@@ -9,7 +9,7 @@ export const createTheme = ({
   bgError = colors.bgRed,
   bgSuccess = colors.bgGreen,
   bgSkip = colors.bgYellow,
-  disableFont = colors.gray,
+  disableFont = colors.dim,
   badgeFont = colors.whiteBright,
   adornerFont = colors.cyan,
 } = {}) => {


### PR DESCRIPTION
On my terminal (GNOME Terminal on Pop!_OS 22.04), with the default (dark) colour scheme, the `colors.gray` color used by `disableFont` is illegible. I tried a few other terminal colour scheme / palette combinations, and `colors.gray` is illegible on about half of them. Is there any chance of changing it to `colors.dim` instead?

Screenshot before:
![image](https://user-images.githubusercontent.com/113399675/211417829-7d17d267-395a-48ff-ab33-cbc8655a384f.png)

Screenshot after:
![image](https://user-images.githubusercontent.com/113399675/211417906-d85ba85d-a9e8-4a33-bc50-d1dec771a44d.png)
